### PR TITLE
feat(5): Added Makefile and systemd service file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+APP_NAME=KakikataShogun.Bot
+PROJECT_DIR=KakikataShogun.Bot
+PUBLISH_DIR=/var/kakikatabot/
+RUNTIME=linux-x64
+SERVICE_NAME=kakikatabot
+SERVICE_FILE=/etc/systemd/system/$(SERVICE_NAME).service
+
+build:
+	dotnet build
+
+run:
+	dotnet run --project $(PROJECT_DIR)
+
+publish:
+	dotnet publish $(PROJECT_DIR) -c Release -r $(RUNTIME) --self-contained true -o $(PUBLISH_DIR)
+
+deploy: publish
+	cp $(SERVICE_NAME).service $(SERVICE_FILE)
+	systemctl daemon-reload
+	systemctl enable $(SERVICE_NAME)
+	systemctl restart $(SERVICE_NAME)
+
+logs:
+	journalctl -u $(SERVICE_NAME) -f
+
+status:
+	systemctl status $(SERVICE_NAME)
+
+restart:
+	systemctl restart $(SERVICE_NAME)
+
+stop:
+	systemctl stop $(SERVICE_NAME)
+
+start:
+	systemctl start $(SERVICE_NAME)

--- a/kakikatabot.service
+++ b/kakikatabot.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=KakikataShogun.Bot
+After=network.target
+
+[Service]
+WorkingDirectory=/var/kakikatabot
+ExecStart=/var/kakikatabot/KakikataShogun.Bot
+Restart=always
+RestartSec=10
+KillSignal=SIGINT
+SyslogIdentifier=kakikatabot
+User=www-data
+Environment=ASPNETCORE_ENVIRONMENT=Production
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This pull request introduces a new build and deployment process for the `KakikataShogun.Bot` project. The changes include a new `Makefile` to automate build, run, publish, and deployment tasks, as well as a new systemd service file to manage the bot as a service.

Build and deployment automation:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R36): Added commands for building, running, publishing, and deploying the `KakikataShogun.Bot` project, including managing the service through systemd.

Service management:

* [`kakikatabot.service`](diffhunk://#diff-267357cbd7f3e2a995d047002f7389b084fdf244ad85ee101104746f755eb936R1-R16): Added a systemd service file to define how the `KakikataShogun.Bot` should be started, stopped, and managed by systemd.