### PR TITLE
Updated the .gitignore and Makefile files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Ignore all binaly files and folders.
 **/bin
 **/obj
+**/publish
 
 # Ignore all transform version for appsettings files.
 **/appsettings.*.json

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 APP_NAME=KakikataShogun.Bot
 PROJECT_DIR=KakikataShogun.Bot
 PUBLISH_DIR=/var/kakikatabot/
+LOCAL_PUBLISH_DIR=publish
 RUNTIME=linux-x64
 SERVICE_NAME=kakikatabot
 SERVICE_FILE=/etc/systemd/system/$(SERVICE_NAME).service
@@ -34,3 +35,10 @@ stop:
 
 start:
 	systemctl start $(SERVICE_NAME)
+
+# Sending binary files and deploying them to the server
+server-deploy:
+	dotnet publish $(PROJECT_DIR) -c Release -r $(RUNTIME) --self-contained true -o $(LOCAL_PUBLISH_DIR)/
+	ssh vdsina-prx "systemctl stop $(SERVICE_NAME)"
+	scp $(LOCAL_PUBLISH_DIR)/* vdsina-prx:$(PUBLISH_DIR)
+	ssh vdsina-prx "systemctl restart $(SERVICE_NAME)"


### PR DESCRIPTION
This pull request includes changes to the `Makefile` to add a new deployment target for the KakikataShogun.Bot project. The most important changes are:

Deployment enhancements:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R4): Added a new variable `LOCAL_PUBLISH_DIR` to specify the local directory for publishing the project.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R38-R44): Introduced a new `server-deploy` target to automate the process of publishing the project, stopping the service on the server, copying the published files to the server, and restarting the service.