### PR TITLE
Updated the message-building process to create multiple strings of me…

### DIFF
--- a/KakikataShogun.Bot/Handlers/TelegramBotUpdateHandler.cs
+++ b/KakikataShogun.Bot/Handlers/TelegramBotUpdateHandler.cs
@@ -31,19 +31,21 @@ internal class TelegramBotUpdateHandler(
             }
         );
 
-        var messageText = await messageBuilder.BuildMessageAsync(
+        var nextMessages = await messageBuilder.BuildMessageAsync(
             update?.Message?.Text ?? string.Empty,
             cancellationToken
         );
 
         if (update?.Message?.Chat.Id is not null)
         {
-            await client.SendMessage(
-                chatId: update.Message.Chat.Id,
-                text: messageText,
-                cancellationToken: cancellationToken
-            );
+            foreach (var message in nextMessages)
+            {
+                await client.SendMessage(
+                    chatId: update.Message.Chat.Id,
+                    text: message,
+                    cancellationToken: cancellationToken
+                );
+            }
         }
     }
 }
-

--- a/KakikataShogun.Bot/Interfaces/IMessageBuilder.cs
+++ b/KakikataShogun.Bot/Interfaces/IMessageBuilder.cs
@@ -3,5 +3,5 @@ namespace KakikataShogun.Bot.Interfaces;
 internal interface IMessageBuilder
 {
     string CommandPattern { get; }
-    Task<string> BuildMessageAsync(string message, CancellationToken cancellationToken);
+    Task<string[]> BuildMessageAsync(string message, CancellationToken cancellationToken);
 }

--- a/KakikataShogun.Bot/MessageBuilders/DefaultMessageBuilder.cs
+++ b/KakikataShogun.Bot/MessageBuilders/DefaultMessageBuilder.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using KakikataShogun.Bot.Interfaces;
 using OpenAI.Chat;
 
@@ -8,9 +7,12 @@ internal class DefaultMessageBuilder(ChatClient openAIClient) : IMessageBuilder
 {
     public string CommandPattern => "default";
 
-    public async Task<string> BuildMessageAsync(string message, CancellationToken cancellationToken)
+    public async Task<string[]> BuildMessageAsync(
+        string message,
+        CancellationToken cancellationToken
+    )
     {
-        var sb = new StringBuilder();
+        var result = new List<string>();
 
         try
         {
@@ -22,22 +24,21 @@ Ensure the grammar, vocabulary, and tone are appropriate for casual, professiona
 If needed, provide a brief explanation of the changes.
 Here is my phrase:
 '{message}'.
-
 Please correct it and make it sound natural."
             );
 
             foreach (var content in completion.Content)
             {
-                sb.Append(content.Text);
+                result.Add(content.Text);
             }
         }
         catch (Exception ex)
         {
             SentrySdk.CaptureException(ex);
 
-            sb.Append($"Error: {ex.Message}");
+            result.Add($"Error: {ex.Message}");
         }
 
-        return sb.ToString();
+        return result.ToArray();
     }
 }

--- a/KakikataShogun.Bot/MessageBuilders/WelcomeMessageBuilder.cs
+++ b/KakikataShogun.Bot/MessageBuilders/WelcomeMessageBuilder.cs
@@ -6,16 +6,20 @@ internal class WelcomeMessageBuilder : IMessageBuilder
 {
     public string CommandPattern => "/start";
 
-    public Task<string> BuildMessageAsync(string message, CancellationToken cancellationToken)
+    public Task<string[]> BuildMessageAsync(string message, CancellationToken cancellationToken)
     {
         return Task.FromResult(
-            @"Welcome, traveler! 🏯⚔️🇺🇸
+            new string[]
+            {
+                @"Welcome, traveler! 🏯⚔️🇺🇸
 
 I am Kakikata Shogun, the master of American English! Once a samurai of the written word, I now train warriors like you to speak like a native.
 
 Ask me about grammar, slang, or pronunciation—I shall guide you to fluency!
 
-⚔️ Train hard. Speak bold. Master English! 🇺🇸💬"
+⚔️ Train hard. Speak bold. Master English! 🇺🇸💬",
+                "Could you write a phrase, and I'll help you with it?",
+            }
         );
     }
 }


### PR DESCRIPTION
This pull request introduces changes to the message-building functionality in the `KakikataShogun.Bot` project. The primary updates involve modifying the `BuildMessageAsync` method to return an array of strings instead of a single string. This change affects multiple files and classes.

### Changes to message-building functionality:

* [`KakikataShogun.Bot/Handlers/TelegramBotUpdateHandler.cs`](diffhunk://#diff-c4ebe2275268774fecd4d57c7432fe7d27bdf7225c22cf47b6ac493006cc5454L34-R51): Updated the `BuildMessageAsync` method call to handle an array of messages and send each message individually in a loop.

* [`KakikataShogun.Bot/Interfaces/IMessageBuilder.cs`](diffhunk://#diff-7578f479650583c12b64d68545cd2527036854eb964118430ab68ef302159243L6-R6): Changed the `BuildMessageAsync` method signature to return a `Task<string[]>` instead of `Task<string>`.

* [`KakikataShogun.Bot/MessageBuilders/DefaultMessageBuilder.cs`](diffhunk://#diff-55632ae1724acd091ad685a4f417991beb61a32f01e9898675ef5f18d6e91017L11-R15): Updated the `BuildMessageAsync` method to return a list of strings instead of a single concatenated string. This involves collecting each piece of content in a list and returning it as an array. [[1]](diffhunk://#diff-55632ae1724acd091ad685a4f417991beb61a32f01e9898675ef5f18d6e91017L11-R15) [[2]](diffhunk://#diff-55632ae1724acd091ad685a4f417991beb61a32f01e9898675ef5f18d6e91017L25-R42)

* [`KakikataShogun.Bot/MessageBuilders/WelcomeMessageBuilder.cs`](diffhunk://#diff-6ca27d44d616b4cf8c70038c724eadc46dc84b1317e41de875c413e253b2f154L9-R22): Modified the `BuildMessageAsync` method to return an array of welcome messages instead of a single string.

### Code cleanup:

* [`KakikataShogun.Bot/MessageBuilders/DefaultMessageBuilder.cs`](diffhunk://#diff-55632ae1724acd091ad685a4f417991beb61a32f01e9898675ef5f18d6e91017L1): Removed unnecessary `using System.Text;` directive.…ssages for Telegram.